### PR TITLE
Update the quotes surrounding for app exe path in registry key value

### DIFF
--- a/PasteIntoFile/Program.cs
+++ b/PasteIntoFile/Program.cs
@@ -65,11 +65,11 @@ namespace PasteAsFile
 			{
 				var key = OpenDirectoryKey().CreateSubKey(@"Background\shell").CreateSubKey("Paste Into File");
 				key = key.CreateSubKey("command");
-				key.SetValue("\"", Application.ExecutablePath + "\" \"%V\"");
+				key.SetValue("" , "\"" + Application.ExecutablePath + "\" \"%V\"");
 
 				key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey("Paste Into File");
 				key = key.CreateSubKey("command");
-				key.SetValue("\"", Application.ExecutablePath + "\" \"%1\"");
+				key.SetValue("" , "\"" + Application.ExecutablePath + "\" \"%1\"");
 				MessageBox.Show("Application has been registered with your system", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Information);
 
 			}


### PR DESCRIPTION
fix double quotes location for the exe path